### PR TITLE
Change Build Test from Matrix

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -22,19 +22,15 @@ jobs:
 
   test:
     name: Unit Tests
-    strategy:
-      matrix:
-        go-version: [1.17.x]
-        platform: [ubuntu-latest]
-
-    runs-on: ${{ matrix.platform }}
+    # Please don't use matrixes. This particular test is tracked in prow's branchprotector
+    runs-on: ubuntu-latest
 
     steps:
 
-      - name: Set up Go ${{ matrix.go-version }}
+      - name: Set up Go 1.17
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.17.x
         id: go
 
       - name: Check out code


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
/cc @chizhg 

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

Part of: https://github.com/knative/test-infra/issues/2985

- Reworking the simpler github actions to allow prow to mark it as required.
- The github treates each matrix permutation as a unique status so when we move to go 1.18 the status that we are tracking for 1.17 
will now be different. Current test status is `"Build (1.17.x, ubuntu-latest)"`
- Once this is merged, can a repo admin run add the new test briefly and run `gh api 
repos/knative/serving/branches/main/protection/required_status_checks/contexts`

/kind enhancement


