### PR TITLE
bump go version to 1.18

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.18.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
 
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
         id: go
 
       - name: Check out code

--- a/.github/workflows/releasability.yaml
+++ b/.github/workflows/releasability.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install Dependencies
         run: go install knative.dev/test-infra/buoy@main

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Install Dependencies
         # https://github.com/kubernetes/release/tree/master/cmd/release-notes

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
         id: go
 
       - name: Check out code
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
         id: go
 
       - name: Check out code
@@ -315,10 +315,10 @@ jobs:
 
     steps:
 
-      - name: Set up Go 1.17.x
+      - name: Set up Go 1.18.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
         id: go
 
       - name: Check out code

--- a/.github/workflows/verify-codegen.yaml
+++ b/.github/workflows/verify-codegen.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Verify Deps and Codegen
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.18.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Prow is already using go1.18 by default