### PR TITLE
Bump golangci-lint-action and let it know we're using go1.18

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -102,7 +102,8 @@ jobs:
         if: steps.golangci_configuration.outputs.files_exists == 'true'
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.43
+          version: v1.46.2
+          args: --go=1.18
 
       - name: Install Tools
         if: ${{ always() }}


### PR DESCRIPTION
Bumping to go1.18 seems to cause a linter to fail 

```
 Running [/home/runner/golangci-lint-1.43.0-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt
  
  goroutine 1 [running]:
  github.com/go-critic/go-critic/checkers.init.9()
  	github.com/go-critic/go-critic@v0.6.1/checkers/checkers.go:58 +0x4b4
  
  Error: golangci-lint exit with code 2
```

The linter is smart to disable broken checks but we need to bump the version and let it know we're using go1.18