### PR TITLE
Bug in style action

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -101,7 +101,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.46.2
-          args: --go=1.19
+          args: --go=1.18
 
       - name: Install Tools
         if: ${{ always() }}


### PR DESCRIPTION
golangci lint action does not work currently wih go1.19, adjust go version to 1.18 for it to work

More context here: https://github.com/golangci/golangci-lint-action/issues/532
