### PR TITLE
:bug: Ensure to remove `.gopath` leftover of update-codegen

### DIFF
--- a/go/downstream-test/action.yaml
+++ b/go/downstream-test/action.yaml
@@ -35,12 +35,12 @@ runs:
       shell: bash
       run: |
         ./hack/update-codegen.sh
+        rm -rf .gopath # ensure to remove the temp GOPATH
 
     - name: Build
       working-directory: ${{ inputs.downstream-path }}
       shell: bash
       run: |
-        set +o pipefail # grep return code is 1 when no lines are found.
         tags="$(go run knative.dev/test-infra/tools/go-ls-tags@latest --joiner=,)"
 
         echo "Building with tags: ${tags}"


### PR DESCRIPTION
# Changes

- :bug: Ensure to remove `.gopath` leftover of update-codegen

/kind bug

Fixes https://github.com/knative/actions/issues/86