### PR TITLE
Enable syncer for test-infra

### DIFF
--- a/.github/workflows/file-syncer.yaml
+++ b/.github/workflows/file-syncer.yaml
@@ -2,6 +2,8 @@ name: File Syncer
 on:
   schedule:
   - cron: '0 1 * * 0' # 6am Pacific, Sunday.
+  # Add this to allow manual triggers of this action.
+  workflow_dispatch:
 
 jobs:
   sync:

--- a/sync/file-syncer-config.yaml
+++ b/sync/file-syncer-config.yaml
@@ -1,16 +1,31 @@
-# group:
-  # Actions excluding releasability
-  # - repos: |
-      # knative/test-infra
-    # files:
-      # - source: sync/workflows/
-        # dest: .github/workflows/
-        # exclude: |
-          # synced-releasability.yaml
+group:
+  # Misc common actions
+  - repos: |
+      knative/test-infra
+    files:
+      - source: sync/workflows/synced-security.yaml
+        dest: .github/workflows/synced-security.yaml
+      - source: sync/workflows/synced-style.yaml
+        dest: .github/workflows/synced-style.yaml
+      - source: sync/workflows/synced-stale.yaml
+        dest: .github/workflows/synced-stale.yaml
+      - source: sync/workflows/synced-verify.yaml
+        dest: .github/workflows/synced-verify.yaml
 
-  # Releasability action
-  # - repos: |
-        # knative/knobots
-    # files:
-        # - source: sync/workflows/synced-releasability.yaml
-          # dest: .github/workflows/synced-releasability.yaml
+  # Golang related actions
+#  - repos: |
+        # <ORG>/<REPO>
+#    files:
+#        - source: sync/workflows/synced-go-build.yaml
+#          dest: .github/workflows/synced-go-build.yaml
+#        - source: sync/workflows/synced-go-test.yaml
+#          dest: .github/workflows/synced-go-test.yaml
+
+  # Release related actions
+#  - repos: |
+        # <ORG>/<REPO>
+#    files:
+#        - source: sync/workflows/synced-releasability.yaml
+#          dest: .github/workflows/synced-releasability.yaml
+#        - source: sync/workflows/synced-release-notes.yaml
+#          dest: .github/workflows/synced-release-notes.yaml


### PR DESCRIPTION
This should enable file syncer for test-infra and set up an idea of how the config will look.

Note that the exclude functionality of file syncer is currently broken https://github.com/BetaHuhn/repo-file-sync-action/issues/276. 