### PR TITLE
Revert "Enable syncer for test-infra"

### DIFF
--- a/.github/workflows/file-syncer.yaml
+++ b/.github/workflows/file-syncer.yaml
@@ -2,8 +2,6 @@ name: File Syncer
 on:
   schedule:
   - cron: '0 1 * * 0' # 6am Pacific, Sunday.
-  # Add this to allow manual triggers of this action.
-  workflow_dispatch:
 
 jobs:
   sync:

--- a/sync/file-syncer-config.yaml
+++ b/sync/file-syncer-config.yaml
@@ -1,31 +1,16 @@
-group:
-  # Misc common actions
-  - repos: |
-      knative/test-infra
-    files:
-      - source: sync/workflows/synced-security.yaml
-        dest: .github/workflows/synced-security.yaml
-      - source: sync/workflows/synced-style.yaml
-        dest: .github/workflows/synced-style.yaml
-      - source: sync/workflows/synced-stale.yaml
-        dest: .github/workflows/synced-stale.yaml
-      - source: sync/workflows/synced-verify.yaml
-        dest: .github/workflows/synced-verify.yaml
+# group:
+  # Actions excluding releasability
+  # - repos: |
+      # knative/test-infra
+    # files:
+      # - source: sync/workflows/
+        # dest: .github/workflows/
+        # exclude: |
+          # synced-releasability.yaml
 
-  # Golang related actions
-#  - repos: |
-        # <ORG>/<REPO>
-#    files:
-#        - source: sync/workflows/synced-go-build.yaml
-#          dest: .github/workflows/synced-go-build.yaml
-#        - source: sync/workflows/synced-go-test.yaml
-#          dest: .github/workflows/synced-go-test.yaml
-
-  # Release related actions
-#  - repos: |
-        # <ORG>/<REPO>
-#    files:
-#        - source: sync/workflows/synced-releasability.yaml
-#          dest: .github/workflows/synced-releasability.yaml
-#        - source: sync/workflows/synced-release-notes.yaml
-#          dest: .github/workflows/synced-release-notes.yaml
+  # Releasability action
+  # - repos: |
+        # knative/knobots
+    # files:
+        # - source: sync/workflows/synced-releasability.yaml
+          # dest: .github/workflows/synced-releasability.yaml


### PR DESCRIPTION
Reverts knative/actions#91

/hold

/cc @kvmware

The new style action is great but it is broken unfortunately.

https://github.com/knative/test-infra/pull/3654

https://github.com/knative/test-infra/actions/runs/3782037318/jobs/6517958542 