### PR TITLE
Disable shellcheck on GHAs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,4 +10,3 @@ jobs:
     uses: knative/actions/.github/workflows/reusable-style.yaml@main
     with:
       yaml: false
-      gha_yaml_path_regex: '**/*.(yaml|yml)'

--- a/composite/style/github_actions/action.yml
+++ b/composite/style/github_actions/action.yml
@@ -12,5 +12,5 @@ runs:
     - uses: actions/checkout@v3
     - uses: reviewdog/action-actionlint@v1
       with:
-        actionlint_flags: ${{ inputs.changed_gha_yaml_files }}
+        actionlint_flags: --shellcheck= ${{ inputs.changed_gha_yaml_files }}
         filter_mode: 'file'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
actionlint runs shellcheck on github actions and does not seem to understand the GHA preferred `"name=value" >> "$GITHUB_ENV"` paradigm without throwing an error.

- :bug: Fix bug
