### PR TITLE
Disable line-length rule for yamlint

### DIFF
--- a/composite/style/yaml/action.yml
+++ b/composite/style/yaml/action.yml
@@ -22,5 +22,8 @@ runs:
 
     - uses: reviewdog/action-yamllint@v1
       with:
-        yamllint_flags: '--no-warnings ${{ inputs.changed_yaml_files }}'
+        yamllint_flags: >
+          -d "{extends: default, rules: {line-length: disable}}"
+          --no-warnings
+          ${{ inputs.changed_yaml_files }}
         filter_mode: 'file'


### PR DESCRIPTION
- :broom: Update or clean up current behavior
