### PR TITLE
Address issue 535 for golangci-lint-action

### DIFF
--- a/.github/workflows/reusable-helper-go-style.yaml
+++ b/.github/workflows/reusable-helper-go-style.yaml
@@ -100,7 +100,7 @@ jobs:
         if: steps.golangci_configuration.outputs.files_exists == 'true'
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.0
+          version: v1.47.3
           args: --go=1.20
 
       - name: Install Tools


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
There is an issue https://github.com/golangci/golangci-lint-action/issues/535 that has golangci-lint-action lint unchanged files which we are now seeing. People report that setting the version `v1.47.3` address this issue.

- :bug: Fix bug
