### PR TITLE
Enable `only-new-issues` for golangci-lint-action to fix linting unch…

### DIFF
--- a/.github/workflows/reusable-helper-go-style.yaml
+++ b/.github/workflows/reusable-helper-go-style.yaml
@@ -100,6 +100,7 @@ jobs:
         if: steps.golangci_configuration.outputs.files_exists == 'true'
         uses: golangci/golangci-lint-action@v3
         with:
+          only-new-issues: true
           version: v1.52.0
           args: --go=1.20
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
There is an issue https://github.com/golangci/golangci-lint-action/issues/535 that has golangci-lint-action lint unchanged files which we are now seeing. People report that setting the version `v1.47.3` address this issue. However, downgrading gets us https://github.com/golangci/golangci-lint-action/issues/440. Setting the  `only-new-issues` flag seems to fix the issue we are experiencing for now.

- :bug: Fix bug
