### PR TITLE
Parse added files only for reviewdog

### DIFF
--- a/composite/style/shell/action.yml
+++ b/composite/style/shell/action.yml
@@ -33,12 +33,10 @@ runs:
     - uses: reviewdog/action-shfmt@v1
       with:
         level: 'warning'
-        reporter: 'github-pr-review'
-        filter_mode: 'file'
+        reporter: 'github-pr-check'
 
     - name: "ShellCheck"
       if: ${{ steps.shellcheck_suggester.outputs.stderr }}
       uses: reviewdog/action-shellcheck@v1
       with:
-        reporter: 'github-pr-review'
-        filter_mode: 'file'
+        reporter: 'github-pr-check'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
reviewdog would have to have the changed files variable passed to each tool otherwise with the files changed which might be vendor files which is a problem. The beginning logic of the suggester handles the changed files fine and has a wider scope.

- :bug: Fix bug
