### PR TITLE
Go vulnerability reporting

### DIFF
--- a/.github/workflows/reusable-security.yaml
+++ b/.github/workflows/reusable-security.yaml
@@ -80,3 +80,25 @@ jobs:
       uses: pierdipi/unicode-control-characters-action@release-0.1
       with:
         args: --detailed --config .unicode-control-characters.config.py .
+
+  govulncheck:
+    name: Go vulnerability Detection
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: ${{ github.workspace }}
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.20.x
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ./src/github.com/${{ github.repository }}
+
+      - name: Govulncheck scan
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- Adds Go vulnerability reporting using the [tool](https://go.dev/security/vuln/) from the Go sec team.

