### PR TITLE
Avoid failing if vulnerabilities are found

### DIFF
--- a/.github/workflows/reusable-security.yaml
+++ b/.github/workflows/reusable-security.yaml
@@ -101,4 +101,4 @@ jobs:
         working-directory: ./src/github.com/${{ github.repository }}
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+          govulncheck ./... || true


### PR DESCRIPTION
# Changes
- govulncheck [breaks other repos such test/infra](https://github.com/knative/test-infra/actions/runs/4680418547/jobs/8291737685?pr=3796) since it returns a non zero value if vulnerabilities are found. 
PR that fails [here](https://github.com/knative/test-infra/pull/3796). Also it does not support silencing (https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck). So here we always return success in order to get at least the reports. In the future we might want to get more strict.

