### PR TITLE
Exclude SC1091 checks

### DIFF
--- a/.github/workflows/reusable-style.yaml
+++ b/.github/workflows/reusable-style.yaml
@@ -33,6 +33,9 @@ jobs:
   # JOB to run change detection
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write 
     # Set job outputs to values from filter step
     outputs:
       golang: ${{ steps.matched.outputs.golang }}

--- a/composite/style/shell/action.yml
+++ b/composite/style/shell/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
     - uses: actions/checkout@v3
     - id: shellcheck_suggester
-      uses: mathiasvr/command-output@v1
+      uses: mathiasvr/command-output@v2
       with:
         run: |
           echo ${{ inputs.changed_shell_files }}
@@ -26,17 +26,20 @@ runs:
       uses: reviewdog/action-suggester@v1
       with:
         level: 'warning'
-        reporter: 'github-pr-review'
         tool_name: shellcheck
         filter_mode: 'file'
 
     - uses: reviewdog/action-shfmt@v1
       with:
         level: 'warning'
-        reporter: 'github-pr-check'
+        reporter: 'github-pr-review'
 
     - name: "ShellCheck"
       if: ${{ steps.shellcheck_suggester.outputs.stderr }}
       uses: reviewdog/action-shellcheck@v1
       with:
-        reporter: 'github-pr-check'
+        reporter: 'github-pr-review'
+        shellcheck_flags: |
+          --external-sources -e=SC1091
+
+


### PR DESCRIPTION
/cc @kvmware 

This change suppresses this error which is in every repo:

```
 REDACTED  C02CW0CDP3YY  ~  Desktop  Git  kn-test-infra   eventing-slack-channels  1✎  1⚑  ERROR  $  shellcheck prow/jobs/run_job.sh --external-sources 

In prow/jobs/run_job.sh line 19:
source "$(dirname "${BASH_SOURCE[0]}")"/../../vendor/knative.dev/hack/library.sh
       ^-- SC1091 (info): Not following: ./../../vendor/knative.dev/hack/library.sh: openBinaryFile: does not exist (No such file or directory)

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./../../vendor/kna...
 REDACTED  C02CW0CDP3YY  ~  Desktop  Git  kn-test-infra   eventing-slack-channels  1✎  1⚑  ERROR  $  shellcheck prow/jobs/run_job.sh --external-sources -e SC1091
```

Also, we grant the worklows access to Reviews API so they can actually write reviews and bumped mathiasvr/command-output@v2 to fix set-output errors