### PR TITLE
removing-redundant-go-fmt

### DIFF
--- a/.github/workflows/reusable-helper-go-style.yaml
+++ b/.github/workflows/reusable-helper-go-style.yaml
@@ -22,18 +22,6 @@ jobs:
   autoformat:
     name: Auto-format and Check
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false # Keep running if one leg fails.
-      matrix:
-        tool:
-          - goimports
-          - gofmt
-
-        include:
-        - tool: gofmt
-          options: -s
-        - tool: goimports
-          package: golang.org/x/tools/cmd/goimports@latest
 
     steps:
       - name: Set up Go
@@ -45,15 +33,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Dependencies
-        if: ${{ matrix.package != '' }}
         run: |
           cd "$(mktemp -d)"
-          go install ${{ matrix.package }}
+          go install golang.org/x/tools/cmd/goimports@latest
 
-      - name: ${{ matrix.tool }} ${{ matrix.options }}
+      - name: goimports
         shell: bash
         run: >
-          ${{ matrix.tool }} ${{ matrix.options }} -w
+          goimports -w
           $(find .
           -path '*/vendor/*' -prune
           -o -path '*/third_party/*' -prune
@@ -61,7 +48,7 @@ jobs:
           -o -name 'wire_gen.go' -prune
           -o -type f -name '*.go' -print)
 
-      - name: Verify ${{ matrix.tool }}
+      - name: Verify goimports
         shell: bash
         run: |
           # From: https://backreference.org/2009/12/23/how-to-match-newlines-in-sed/
@@ -72,9 +59,9 @@ jobs:
           }
           if [[ $(git diff-index --name-only HEAD --) ]]; then
               for x in $(git diff-index --name-only HEAD --); do
-                echo "::error file=$x::Please run ${{ matrix.tool }} ${{ matrix.options }}.%0A$(git diff "$x" | urlencode)"
+                echo "::error file=$x::Please run goimports.%0A$(git diff "$x" | urlencode)"
               done
-              echo "${{ github.repository }} is out of style. Please run ${{ matrix.tool }} ${{ matrix.options }}."
+              echo "${{ github.repository }} is out of style. Please run goimports."
               exit 1
           fi
           echo "${{ github.repository }} is formatted correctly."


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

Removing gofmt as goimports does the work of gofmt

Fixes #115

