### PR TITLE
Shell style action enhancements

### DIFF
--- a/composite/style/shell/action.yml
+++ b/composite/style/shell/action.yml
@@ -15,6 +15,7 @@ runs:
     - id: shellcheck_suggester
       uses: mathiasvr/command-output@v2.0.0
       with:
+        # Remove vendor/ so actions don't try linting files in it
         run: |
           echo ${{ inputs.changed_shell_files }}
           for sh_file in ${{ inputs.changed_shell_files }}; do

--- a/composite/style/shell/action.yml
+++ b/composite/style/shell/action.yml
@@ -20,6 +20,8 @@ runs:
           for sh_file in ${{ inputs.changed_shell_files }}; do
             shellcheck -f diff $sh_file | patch -p1
           done
+
+          rm -rf vendor/
         shell: bash
       continue-on-error: true
     - name: suggester / shellcheck
@@ -39,6 +41,7 @@ runs:
       uses: reviewdog/action-shellcheck@v1
       with:
         reporter: 'github-pr-review'
+        exclude: './vendor/*'
         shellcheck_flags: |
           --external-sources -e=SC1091
 

--- a/composite/style/shell/action.yml
+++ b/composite/style/shell/action.yml
@@ -34,7 +34,7 @@ runs:
     - uses: reviewdog/action-shfmt@v1
       with:
         level: 'warning'
-        reporter: 'github-pr-review'
+        reviewdog_flags: -reporter=github-pr-review
 
     - name: "ShellCheck"
       if: ${{ steps.shellcheck_suggester.outputs.stderr }}


### PR DESCRIPTION
# Changes

- Don't run the shell style actions in the vendor directory
- Pass the `reporter` config to `action-shfmt` as a `reviewdog_flags` config to prevent the following warning:
```
Warning: Unexpected input(s) 'reporter', valid inputs are ['github_token', 'workdir', 'level', 'filter_mode', 'fail_on_error', 'reviewdog_flags', 'shfmt_flags']
```

Fixes #145 

