### PR TITLE
Exclude `third_party` folders from style checks

### DIFF
--- a/.github/workflows/reusable-style.yaml
+++ b/.github/workflows/reusable-style.yaml
@@ -54,15 +54,15 @@ jobs:
         list-files: 'shell' # list files in for shell consumption
         filters: |
           golang:
-            - '!(vendor/**)**.go'
+            - '!(vendor/**|third_party/**)**.go'
           shell:
-            - '!(vendor/**)**.sh'
+            - '!(vendor/**|third_party/**)**.sh'
           markdown:
-            - '!(vendor/**)**.md'
-            - '!(vendor/**)**.MD'
+            - '!(vendor/**|third_party/**)**.md'
+            - '!(vendor/**|third_party/**)**.MD'
           yaml:
-            - '!(.github/workflows/**|vendor/**)**.yaml'
-            - '!(.github/workflows/**|vendor/**)**.yml'
+            - '!(.github/workflows/**|vendor/**|third_party/**)**.yaml'
+            - '!(.github/workflows/**|vendor/**|third_party/**)**.yml'
           gha_yaml:
             - '${{ inputs.gha_yaml_path_regex }}'
 


### PR DESCRIPTION
Some repositories have `third_party` folders (e.g. [eventing-istio](https://github.com/knative-sandbox/eventing-istio/tree/main/third_party)), which code styles are kind out of our control. Therefor we should exclude these subfolders form the style checks.