### PR TITLE
Remove reporter config from action-shfmt

### DIFF
--- a/composite/style/shell/action.yml
+++ b/composite/style/shell/action.yml
@@ -35,7 +35,6 @@ runs:
     - uses: reviewdog/action-shfmt@v1
       with:
         level: 'warning'
-        reviewdog_flags: -reporter=github-pr-review
 
     - name: "ShellCheck"
       if: ${{ steps.shellcheck_suggester.outputs.stderr }}


### PR DESCRIPTION
# Changes

- Related [commit](https://github.com/knative/actions/commit/dba968a2068ecaa4be1fd0bb9aedde16c9a37971)
- The shfmt action does not accept the `reporter` config (either as part of `with` or passed in as a `reviewdog_flags`) so this PR removes it from the action-shfmt configuration.
