### PR TITLE
Update reusable-helper-go-style.yaml

### DIFF
--- a/.github/workflows/reusable-helper-go-style.yaml
+++ b/.github/workflows/reusable-helper-go-style.yaml
@@ -88,7 +88,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           only-new-issues: true
-          version: v1.52.0
+          version: v1.55.2
           args: --go=1.21
 
       - name: Install Tools


### PR DESCRIPTION
Context: Golang lint has some weird errors on Serving CI in version 1.52.0 with golang 1.21. Tested it locally with latest version without issues: https://github.com/knative/serving/pull/14610#issuecomment-1833795301

# Change
- Bump golangci-lint to version 1.55.2

/assign @skonto
/assign @dprotaso 
/assign @krsna-m 