### PR TITLE
Allow secrets inheritance in unit test workflow

### DIFF
--- a/sync/workflows/synced-go-test.yaml
+++ b/sync/workflows/synced-go-test.yaml
@@ -15,3 +15,5 @@ on:
 jobs:
   test:
     uses: knative/actions/.github/workflows/reusable-go-test.yaml@main
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Allow secrets inheritance in unit test workflow

@upodroid @cardil PTAL

A follow-up to my previous PR #211 per docs:
https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow