### PR TITLE
Add codecov token to reusable action inputs

### DIFF
--- a/.github/workflows/reusable-go-test.yaml
+++ b/.github/workflows/reusable-go-test.yaml
@@ -16,7 +16,11 @@ name: Test
 
 on:
 
-  workflow_call: {}
+  workflow_call: 
+    secrets:
+      CODECOV_TOKEN:
+        description: 'Token to upload Codecov coverage reports from action'
+        required: true 
 
 jobs:
 


### PR DESCRIPTION
FYI @Cali0707 

Once again, I haven't read the docs completely and assumed `secrets:` inputs don't required definition on yamls. 

/cc @cardil @upodroid 