### PR TITLE
Pin python version to 3.11

### DIFF
--- a/composite/style/yaml/action.yml
+++ b/composite/style/yaml/action.yml
@@ -13,7 +13,10 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v3
-    - run: pip install --break-system-packages yamlfixer-opt-nc
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"   
+    - run: pip install yamlfixer-opt-nc
       shell: bash
     - run: yamlfixer -C $YAMLLINT_RULES ${{ inputs.changed_yaml_files }}
       shell: bash


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Pin python version to 3.11

@upodroid PTAL, we have noticed that GH runners may vary on Ubuntu version. Spanning between 24 and 22 LTS release, the culprit is that Ubuntu 22 has default Python 3.10 that doesn't have `--break-system-package` yet. For our limited use case it seems like a good enough to pin the version. WDYT?

https://github.com/actions/runner-images/blob/ubuntu22/20241006.1/images/ubuntu/Ubuntu2204-Readme.md#language-and-runtime

FYI, per our chat earlier.
/cc @ReToCode @skonto 