### PR TITLE
Specify directories containing action.yml files

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,8 +4,10 @@ updates:
   - package-ecosystem: "github-actions"
     directories: 
       - "/"
-      - "/composite"
-      - "/go"
+      - "/composite/style/github_actions"
+      - "/composite/style/gofmt"
+      - "/composite/style/shell"
+      - "/composite/style/yaml"
       - "/setup-go"
     schedule:
       # Check for updates to GitHub Actions every week


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Specify directories containing action.yml files

Directories are not traversed further, per the error and actual dependabot feature issue.
```
updater | 2024/10/16 07:42:53 ERROR <job_901912085> Error during file fetching; aborting: /composite/<anything>.yml not found

```

/cc @upodroid 