### PR TITLE
Bump golang to 1.23

### DIFF
--- a/setup-go/action.yaml
+++ b/setup-go/action.yaml
@@ -19,4 +19,4 @@ runs:
     - name: setup go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ inputs.go-version || '1.22' }}
+        go-version: ${{ inputs.go-version || '1.23' }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Bump golang to 1.23

@upodroid @dprotaso @knative/knative-release-leads I wonder if we should jump on Go 1.23 before the next release cycle. What's your preference? 
I'll follow-up with knative/infra PR for prow images if we agree to proceed.   