### PR TITLE
Bump golangci-lint version

### DIFF
--- a/.github/workflows/reusable-helper-go-style.yaml
+++ b/.github/workflows/reusable-helper-go-style.yaml
@@ -84,8 +84,8 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           only-new-issues: true
-          version: v1.59.1
-          args: --go=1.22
+          version: v1.62.2
+          args: --go=1.23
 
       - name: Install Tools
         if: ${{ always() }}


### PR DESCRIPTION
# Changes

- :broom: Bump golangci-lint version so it works with newer Go version. The older version was getting OOM with newer Go.
*NOTE*: this might introduce new warning in knative projects, we will have to update them accordingly.
