### PR TITLE
Update go-style action to use golangci-lint v2.0

### DIFF
--- a/.github/workflows/reusable-helper-go-style.yaml
+++ b/.github/workflows/reusable-helper-go-style.yaml
@@ -84,8 +84,7 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         with:
           only-new-issues: true
-          version: v1.64.6
-          args: --go=1.24
+          version: v2.0
 
       - name: Install Tools
         if: ${{ always() }}


### PR DESCRIPTION
In #249 the golangci-lint-action was updated to v7. Anyhow v7 only supports golangci-lint = v (see [here](https://github.com/marketplace/actions/golangci-lint#compatibility)):

> v7.0.0 supports golangci-lint v2 only.

Also removing the `go` flag, as this seems not to be supported in golangci-lint v2 anymore