### PR TITLE
bump golangci version that works with the action

### DIFF
--- a/.github/workflows/reusable-helper-go-style.yaml
+++ b/.github/workflows/reusable-helper-go-style.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           only-new-issues: true
-          version: v2.0
+          version: v2.3
 
       - name: Install Tools
         if: ${{ always() }}


### PR DESCRIPTION
This PR (https://github.com/knative/actions/pull/254) broke the action because we needed to bump the golangci version

