### PR TITLE
Fix downstream test license

### DIFF
--- a/go/downstream-test/action.yaml
+++ b/go/downstream-test/action.yaml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: |
         go mod edit -replace ${{ env.UPSTREAM_MODULE }}=$GITHUB_WORKSPACE/${{ inputs.upstream-path }}
-        echo GO_LICENSES_FLAGS="--ignore ${{ env.UPSTREAM_MODULE }}" >> $GITHUB_ENV    
+        echo GO_LICENSES_FLAGS="${GO_LICENSES_FLAGS:-} --ignore ${{ env.UPSTREAM_MODULE }}" >> $GITHUB_ENV    
 
     - name: Downstream Update Deps
       working-directory: ${{ inputs.downstream-path }}

--- a/go/downstream-test/action.yaml
+++ b/go/downstream-test/action.yaml
@@ -23,6 +23,7 @@ runs:
       shell: bash
       run: |
         go mod edit -replace ${{ env.UPSTREAM_MODULE }}=$GITHUB_WORKSPACE/${{ inputs.upstream-path }}
+        echo GO_LICENSES_FLAGS="--ignore ${{ env.UPSTREAM_MODULE }}" >> $GITHUB_ENV    
 
     - name: Downstream Update Deps
       working-directory: ${{ inputs.downstream-path }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Fix downstream test license

There's an issue in `go-licenses@v2` that is following replace path and reports failing check for local replacement. I.e. the one kind we do in downstream-style tests.

https://github.com/google/go-licenses/issues/310

Test PR trigger: https://github.com/dsimansk/networking/pull/1 

Per our chat on Slack.
/cc @dprotaso 